### PR TITLE
Fix: isActivityExecutor was comparing the wrong class name

### DIFF
--- a/src/main/java/de/dfki/vsm/xtesting/NewPropertyManager/util/ExtensionsFromJar.java
+++ b/src/main/java/de/dfki/vsm/xtesting/NewPropertyManager/util/ExtensionsFromJar.java
@@ -57,7 +57,7 @@ public class ExtensionsFromJar {
      */
     public boolean isClassAnActivityExecutor(String className) {
         return new Reflections(packageName).getSubTypesOf(ActivityExecutor.class).stream()
-                .anyMatch(aClass -> aClass.getSimpleName().equals(className));
+                .anyMatch(aClass -> aClass.getCanonicalName().equals(className));
     }
 
 }


### PR DESCRIPTION
Because of this the editor did not allow to add agents for activityexecutors. This should be possible again now