### PR TITLE
Add main method for core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,9 @@ compileJava {options.encoding = "UTF-8"}
 javadoc { options.encoding = 'UTF-8' }
 
 group 'de.dfki'
-version '4.1.0-' + versioning.info.full
+allprojects {
+    version = versioning.info.lastTag
+}
 
 sourceCompatibility = 11
 
@@ -79,7 +81,9 @@ jar {
         attributes(
                 'Main-Class': 'de.dfki.vsm.SceneMaker3',
                 'build' : versioning.info.build,
-                'Build-Revision': versioning.info.commit
+                'Build-Revision': versioning.info.commit,
+                'Full-Version': versioning.info.full,
+                'Last-Tag': versioning.info.lastTag
         )
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,8 +2,6 @@ plugins {
     id 'java'
 }
 
-
-
 group 'de.dfki.vsm'
 
 targetCompatibility = 1.8
@@ -11,7 +9,7 @@ sourceCompatibility = 1.8
 
 if(!project.hasProperty('flavor')){
     apply plugin: 'java'
-    version "android-4.0.1" ;
+    version "android-4.0.1"
 
     println("Building jar for ANDROID")
 }

--- a/core/src/main/java/de/dfki/vsm/Core.java
+++ b/core/src/main/java/de/dfki/vsm/Core.java
@@ -73,4 +73,20 @@ public class Core {
             }
         }
     }
+    public static void main(String[] args){
+        if (args.length == 2) {
+            // Read the first command line argument
+            final String mode = args[0];
+            // Get the project file name argument
+            final String name = args[1];
+            // Create the project configuration
+            final File file = new File(name);
+            // Check the options from this argument
+            if (file.exists()) {
+                if (mode.equals("runtime")) {
+                    Core.runtime(file);
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Adding a main method for the core makes it easier to build headless versions of scenemaker with other plugins, but no editor