### PR TITLE
Fixing null pointer exception when executed sceneflow was paused and …

### DIFF
--- a/src/main/java/de/dfki/vsm/editor/Edge.java
+++ b/src/main/java/de/dfki/vsm/editor/Edge.java
@@ -982,7 +982,9 @@ public class Edge extends JComponent implements EventListener, Observer, MouseLi
                     }
 
                     mVisualisationTask = new VisualisationTask(mEditorConfig.sVISUALISATIONTIME, this);
-                    mVisualisationTimer.schedule(mVisualisationTask, 0, 15);
+                    if (mVisualisationTimer != null) {
+                        mVisualisationTimer.schedule(mVisualisationTask, 0, 15);
+                    }
                 }
             }
         }


### PR DESCRIPTION
…started again. Then, a new mVisualisationTimer was created. The old was is set to null and the update method wants to use the old one one last time. Added check if the instance is null.